### PR TITLE
SystemUI: fix navbar dpad arrow keys regression

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NavigationBarView.java
@@ -422,12 +422,12 @@ public class NavigationBarView extends LinearLayout {
             View one = getCurrentView().findViewById(mVertical ? R.id.six : R.id.one);
             View six = getCurrentView().findViewById(mVertical ? R.id.one : R.id.six);
             if (showingIme) {
-                if (mSlotOneVisibility == View.VISIBLE) {
-                    mSlotOneVisibility = one.getVisibility();
+                if (mSlotOneVisibility == View.VISIBLE || one.getVisibility() == View.VISIBLE) {
+                    mSlotOneVisibility = View.VISIBLE;
                     setVisibleOrGone(one, false);
                 }
-                if (mSlotSixVisibility == View.VISIBLE) {
-                    mSlotSixVisibility = six.getVisibility();
+                if (mSlotSixVisibility == View.VISIBLE || six.getVisibility() == View.VISIBLE) {
+                    mSlotSixVisibility = View.VISIBLE;
                     setVisibleOrGone(six, false);
                 }
             } else {


### PR DESCRIPTION
A previous commit (3dcd3654257f0cf41b50ad3a544eaa7902386a4a) which
was supposed to improve the dpad showing logic when swiching IMEs caused
a regression in that it did not hide small navbar buttons on the side
which were not the menu button. This is because the logic to store the
previous butotn visibility went through setButtonWithTagVisibility()
which is really only called on the primary buttons + menu button, and
never the search button.

Always store the previous visibilities of the buttons we're about to
override, so they can be restored properly.

Change-Id: I6d0dee7fe7918613b5d8ca7a81adfd631acffc1e
Signed-off-by: Roman Birg <roman@cyngn.com>