### PR TITLE
core: Protect against system server take down on empty tile order.

### DIFF
--- a/core/java/com/android/internal/util/cm/QSUtils.java
+++ b/core/java/com/android/internal/util/cm/QSUtils.java
@@ -209,7 +209,7 @@ public class QSUtils {
         final ContentResolver resolver = context.getContentResolver();
         String order = Settings.Secure.getStringForUser(resolver,
                 Settings.Secure.QS_TILES, userId);
-        return Arrays.asList(order.split(",")).contains(tileSpec);
+        return !TextUtils.isEmpty(order) && Arrays.asList(order.split(",")).contains(tileSpec);
     }
 
     public static ContentObserver registerObserverForQSChanges(Context ctx, final OnQSChanged cb) {


### PR DESCRIPTION
  If a user, for whatever reason, removes all the tiles available
  in the QSPanel, any query to #isQSTileEnabledForUser would result
  in an NPE. With the introduction of Dynamic Tiles, this issue
  is exacerbated causing a full SystemServer take down.

Change-Id: Ic433d98170470f8cc692ffce4811ab005e265f04