### PR TITLE
Fingerprint Service: fix potential NPE

### DIFF
--- a/services/core/java/com/android/server/fingerprint/FingerprintService.java
+++ b/services/core/java/com/android/server/fingerprint/FingerprintService.java
@@ -367,7 +367,9 @@ public class FingerprintService extends SystemService {
                      it.hasNext(); ) {
                     try {
                         ClientData clientData = it.next().getValue();
-                        clientData.receiver.onStateChanged(mState);
+                        if (clientData != null && clientData.receiver != null) {
+                            clientData.receiver.onStateChanged(mState);
+                        }
                     } catch(RemoteException e) {
                         Slog.e(TAG, "can't send message to client. Did it die?", e);
                         it.remove();


### PR DESCRIPTION
The client receiver can be null (and there are null checks elsewhere it
is accessed), so we should make sure it is not, before trying to update
its state.

Ref: CYNGNOS-832

Change-Id: I4063f209102f9c42f7491aae752384b1654be3e9
Signed-off-by: Roman Birg <roman@cyngn.com>