### PR TITLE
Set mProximity to PROXIMITY_UNKNOWN on screen off

### DIFF
--- a/services/core/java/com/android/server/display/DisplayPowerController.java
+++ b/services/core/java/com/android/server/display/DisplayPowerController.java
@@ -567,6 +567,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
             } else {
                 setProximitySensorEnabled(false);
                 mWaitingForNegativeProximity = false;
+                mProximity = PROXIMITY_UNKNOWN;
             }
             if (mScreenOffBecauseOfProximity
                     && mProximity != PROXIMITY_POSITIVE) {


### PR DESCRIPTION
In the case where the screen was already off do to the proximity
sensor and the user presses the power button, we need to set
mProximity to PROXIMITY_UNKNOWN so that when the screen comes back
on and the proximity sensor is re-enabled it will be able to pick
up the change in proximity.

Change-Id: I53fc5d34597422546239bb71641355ca1aa5dea8
REF: CRACKLING-554