### PR TITLE
SettingsProvider: don't set default value for advanced mode

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2702,9 +2702,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             loadBooleanSetting(stmt, Settings.Secure.STATS_COLLECTION,
                     R.bool.def_cm_stats_collection);
 
-            loadBooleanSetting(stmt, Settings.Secure.ADVANCED_MODE,
-                    com.android.internal.R.bool.config_advancedSettingsMode);
-
             loadBooleanSetting(stmt, Settings.Secure.SPELL_CHECKER_ENABLED,
                     R.bool.def_spell_checker);
 


### PR DESCRIPTION
The config value is not a default, but rather a 'always-on' switch.
Advanced mode should always be off by default on devices it shows up on
(aka retail user builds).

Ref: CYNGNOS-815

Change-Id: Ia017dd4bac726b445f2fc2b43bfbd0d2833eee0e
Signed-off-by: Roman Birg <roman@cyngn.com>