### PR TITLE
Lights with screen on: Don't disable leds after the lockscreen

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -845,8 +845,11 @@ public class NotificationManagerService extends SystemService {
                 }
             } else if (action.equals(Intent.ACTION_USER_PRESENT)) {
                 // turn off LED when user passes through lock screen
-                mNotificationLight.turnOff();
-                mStatusBar.notificationLightOff();
+                // if lights with screen on is disabled.
+                if (!mScreenOnEnabled) {
+                    mNotificationLight.turnOff();
+                    mStatusBar.notificationLightOff();
+                }
             } else if (action.equals(Intent.ACTION_USER_SWITCHED)) {
                 // reload per-user settings
                 mSettingsObserver.update(null);


### PR DESCRIPTION
- If lights with screen on is enabled, do not disable leds
  when user passes through the lockscreen.

Change-Id: If8f5b867a34be09fb061bb7ad040b16730f4e263
Signed-off-by: AdrianDC <radian.dc@gmail.com>