### PR TITLE
Fixed: Wrong status bar notification layout width.

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/IconMerger.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/IconMerger.java
@@ -28,19 +28,33 @@ public class IconMerger extends LinearLayout {
     private static final String TAG = "IconMerger";
     private static final boolean DEBUG = false;
 
-    private int mIconSize;
+    private int mIconWidth;
     private int mClockLocation;
     private View mMoreView;
 
     public IconMerger(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        mIconSize = context.getResources().getDimensionPixelSize(
-                R.dimen.status_bar_icon_size);
+        mIconWidth = calculateIconWidth(context);
 
         if (DEBUG) {
             setBackgroundColor(0x800099FF);
         }
+    }
+
+    /**
+     * Considering the padding, this method calculates the effective icon width
+     * of the notification icons.
+     *
+     * @param context
+     * @return The effective icon width which is expected by the {@link IconMerger}.
+     */
+    public static int calculateIconWidth(final Context context) {
+        int iconSize = context.getResources().getDimensionPixelSize(
+                R.dimen.status_bar_icon_size);
+        int iconHPadding = context.getResources().getDimensionPixelSize(
+                R.dimen.status_bar_icon_padding);
+        return iconSize + 2 * iconHPadding;
     }
 
     public void setOverflowIndicator(View v) {
@@ -54,9 +68,9 @@ public class IconMerger extends LinearLayout {
         int width = getMeasuredWidth();
         if (mClockLocation == Clock.STYLE_CLOCK_CENTER) {
             int totalWidth = mContext.getResources().getDisplayMetrics().widthPixels;
-            width = totalWidth / 2 - mIconSize * 2;
+            width = totalWidth / 2 - mIconWidth * 2;
         }
-        setMeasuredDimension(width - (width % mIconSize), getMeasuredHeight());
+        setMeasuredDimension(width - (width % mIconWidth), getMeasuredHeight());
     }
 
     @Override
@@ -79,11 +93,11 @@ public class IconMerger extends LinearLayout {
             int totalWidth = mContext.getResources().getDisplayMetrics().widthPixels;
             if ((mClockLocation != Clock.STYLE_CLOCK_CENTER &&
                     mClockLocation != Clock.STYLE_CLOCK_LEFT) ||
-                    (visibleChildren > (totalWidth / mIconSize / 2 + 1))) {
+                    (visibleChildren > (totalWidth / mIconWidth / 2 + 1))) {
                 visibleChildren--;
             }
         }
-        final boolean moreRequired = visibleChildren * mIconSize > width;
+        final boolean moreRequired = visibleChildren * mIconWidth > width;
         if (moreRequired != overflowShown) {
             post(new Runnable() {
                 @Override

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -933,7 +933,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         updateDisplaySize(); // populates mDisplayMetrics
         updateResources(null);
 
-        mIconSize = res.getDimensionPixelSize(com.android.internal.R.dimen.status_bar_icon_size);
+        mIconSize = res.getDimensionPixelSize(R.dimen.status_bar_icon_size);
 
         mStatusBarWindowContent = (FrameLayout) View.inflate(context,
                 R.layout.super_status_bar, null);
@@ -2066,8 +2066,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     }
 
     private void updateNotificationIcons() {
+        final int effectiveIconWidth = IconMerger.calculateIconWidth(mContext);
         final LinearLayout.LayoutParams params
-            = new LinearLayout.LayoutParams(mIconSize + 2*mIconHPadding, mNaturalBarHeight);
+            = new LinearLayout.LayoutParams(effectiveIconWidth, mNaturalBarHeight);
 
         ArrayList<Entry> activeNotifications = mNotificationData.getActiveNotifications();
         final int N = activeNotifications.size();
@@ -4154,7 +4155,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 com.android.internal.R.dimen.status_bar_height);
 
         int newIconSize = res.getDimensionPixelSize(
-            com.android.internal.R.dimen.status_bar_icon_size);
+            R.dimen.status_bar_icon_size);
         int newIconHPadding = res.getDimensionPixelSize(
             R.dimen.status_bar_icon_padding);
 


### PR DESCRIPTION
The layout of the status bar which surrounds the notification icons
should be a multiple of the notification icon width. Previous calculation
ensured to be a multiple of the notification icon height.

Change-Id: I35faf50b75f7521116065568b9f9142f16fbae2d