### PR TITLE
Fix FileManager Interaction

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -3351,6 +3351,17 @@ public class PackageManagerService extends IPackageManager.Stub {
                     return ri;
                 }
                 return mResolveInfo;
+            } else if (shouldIncludeResolveActivity(intent)) {
+                if (userId != 0) {
+                    ResolveInfo ri = new ResolveInfo(mResolveInfo);
+                    ri.activityInfo = new ActivityInfo(ri.activityInfo);
+                    ri.activityInfo.applicationInfo = new ApplicationInfo(
+                            ri.activityInfo.applicationInfo);
+                    ri.activityInfo.applicationInfo.uid = UserHandle.getUid(userId,
+                            UserHandle.getAppId(ri.activityInfo.applicationInfo.uid));
+                    return ri;
+                }
+                return mResolveInfo;
             }
         }
         return null;
@@ -3648,9 +3659,6 @@ public class PackageManagerService extends IPackageManager.Stub {
                 if (resolveInfo != null) {
                     result.add(resolveInfo);
                     Collections.sort(result, mResolvePrioritySorter);
-                }
-                if (result.size() == 0 && shouldIncludeResolveActivity(intent)) {
-                    result.add(mResolveInfo);
                 }
                 return result;
             }


### PR DESCRIPTION
After much thought about this last night, I decided that we can't
handle making sure the situation in
http://developer.android.com/training/basics/intents/sending.html#StartActivity
can actually be handled without possibly making a bad experience in
other situations (such as FileManager doing its own resolving).

This will now only pop it up when we query a function which could
possibly return the resolver like how it was before  the previous change.

Change-Id: I2e458a80d3e3f7c358949c210b5372933910ac7a
Issue-Id: CYNGNOS-1152