### PR TITLE
BatteryService: Prevent UUC scenarios at 0%

### DIFF
--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -306,8 +306,10 @@ public final class BatteryService extends SystemService {
 
     private void shutdownIfNoPowerLocked() {
         // shut down gracefully if our battery is critically low and we are not powered.
+        // or the battery voltage is decreasing (consumption rate higher than charging rate)
         // wait until the system has booted before attempting to display the shutdown dialog.
-        if (mBatteryProps.batteryLevel == 0 && !isPoweredLocked(BatteryManager.BATTERY_PLUGGED_ANY)) {
+        if (mBatteryProps.batteryLevel == 0 && (!isPoweredLocked(BatteryManager.BATTERY_PLUGGED_ANY) ||
+                                                 mBatteryProps.batteryVoltage < mLastBatteryVoltage) ) {
             mHandler.post(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
If the battery is at 0% and we're plugged to a power source, we were
assuming the device is charging and leaving it fully active. This could
lead to an unusable capacity scenario if the device was busy with high-power
tasks (camcorder, GPS, games, depends on hardware) that caused the discharge
rate to be higher than the charge rate, taking the battery all the way down
to an undervoltage lockout.

Triggering an UVLO was, in some cases, as easy as turning on GPS navigation
while using a car charger...

Change-Id: I0f805880309bf12142203badd1e33db6e37da9c1