### PR TITLE
Fix rotation tile animation

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/RotationLockTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/RotationLockTile.java
@@ -96,6 +96,10 @@ public class RotationLockTile extends QSTile<QSTile.BooleanState> {
                 : mController.isRotationLocked();
         final boolean userInitiated = arg != null ? ((UserBoolean) arg).userInitiated : false;
         state.visible = mController.isRotationLockAffordanceVisible();
+        if (state.value == rotationLocked && state.contentDescription != null) {
+            // No change and initialized, no need to update all the values.
+            return;
+        }
         state.value = rotationLocked;
         final boolean portrait = mContext.getResources().getConfiguration().orientation
                 != Configuration.ORIENTATION_LANDSCAPE;


### PR DESCRIPTION
Don't call setAllowAnimation unless there is a state change.
Also don't bother updating the rest of the state as it hasn't
changed.

Bug: 21337755
Change-Id: Ia3357e075c8e65fdb83232b685332c98e16c291d

---

Fix invisible rotation tile

Make sure we set the state at least once.

Bug: 21837219
Change-Id: Iabd0524f0c09fd3f7b895007204ddf49af19ea98