### PR TITLE
Revert "Only accept user rotations when in USER_ROTATION_FREE mode"

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -6430,9 +6430,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 boolean useSensorRotation =
                         orientation == ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR
                         || orientation == ActivityInfo.SCREEN_ORIENTATION_FULL_USER
-                        || (mUserRotationMode == WindowManagerPolicy.USER_ROTATION_FREE
-                            && RotationPolicy.isRotationAllowed(sensorRotation, mUserRotationAngles,
-                            mAllowAllRotations != 0));
+                        || RotationPolicy.isRotationAllowed(sensorRotation, mUserRotationAngles,
+                                mAllowAllRotations != 0);
                 if (useSensorRotation) {
                     preferredRotation = sensorRotation;
                 } else {


### PR DESCRIPTION
Seems to break the scenario when the app is requesting sensorLandscape, and the user has 90/270 enabled, the system won't rotate to that rotation.

Ref: OSS NIGHTLIES-1976

This reverts commit 51bdbe7976a83f69bc39e520c32239ca26ec86a0.

Change-Id: I227bc5662909efa3ef7ed806496e51ef0e23cacd